### PR TITLE
Resize text from bubble to match the size of bubble.

### DIFF
--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -398,7 +398,9 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
 
         paint.textSize = testTextSize
         val bounds = Rect()
-        paint.getTextBounds(text, 0, text!!.length, bounds)
+        if (text != null) {
+            paint.getTextBounds(text, 0, text.length, bounds)
+        }
 
         val desiredTextSize = testTextSize * desiredWidth / bounds.width()
         paint.textSize = desiredTextSize

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -380,40 +380,19 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
         canvas.drawOval(rectLabel, paintLabel)
 
         val text = bubbleText ?: (position * 100).toInt().toString()
-        if (text.length > 4)
+        if (text.length > 3)
             setTextSizeForWidth(paintTextBubble, rectLabel.width() - 10, bubbleText)
         drawText(canvas, paintTextBubble, text, Paint.Align.CENTER, colorBubbleText, 0f, rectLabel, rectText)
     }
 
-    /**
-     * Sets the text size for a Paint object so a given string of text will be a
-     * given width.
-     *
-     * @param paint
-     * the Paint to set the text size for
-     * @param desiredWidth
-     * the desired width
-     * @param text
-     * the text that should be that width
-     */
-    private fun setTextSizeForWidth(paint: Paint, desiredWidth: Float,
-                                    text: String?) {
-
-        // Pick a reasonably large value for the test. Larger values produce
-        // more accurate results, but may cause problems with hardware
-        // acceleration. But there are workarounds for that, too; refer to
-        // http://stackoverflow.com/questions/6253528/font-size-too-large-to-fit-in-cache
+    private fun setTextSizeForWidth(paint: Paint, desiredWidth: Float, text: String?) {
         val testTextSize = 48f
 
-        // Get the bounds of the text, using our testTextSize.
         paint.textSize = testTextSize
         val bounds = Rect()
         paint.getTextBounds(text, 0, text!!.length, bounds)
 
-        // Calculate the desired size as a proportion of our testTextSize.
         val desiredTextSize = testTextSize * desiredWidth / bounds.width()
-
-        // Set the paint for that size.
         paint.textSize = desiredTextSize
     }
 

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -205,6 +205,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
         val startText: String?
         val endText: String?
         val textSize: Float
+        val textSizeBubble: Float
         val colorLabel: Int
         val colorBar: Int
         val colorBarText: Int
@@ -216,6 +217,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
                     startText: String?,
                     endText: String?,
                     textSize: Float,
+                    textSizeBubble: Float,
                     colorLabel: Int,
                     colorBar: Int,
                     colorBarText: Int,
@@ -225,6 +227,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
             this.startText = startText
             this.endText = endText
             this.textSize = textSize
+            this.textSizeBubble = textSizeBubble
             this.colorLabel = colorLabel
             this.colorBar = colorBar
             this.colorBarText = colorBarText
@@ -237,6 +240,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
             this.startText = parcel.readString()
             this.endText = parcel.readString()
             this.textSize = parcel.readFloat()
+            this.textSizeBubble = parcel.readFloat()
             this.colorLabel = parcel.readInt()
             this.colorBar = parcel.readInt()
             this.colorBarText = parcel.readInt()
@@ -249,6 +253,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
             parcel.writeString(startText)
             parcel.writeString(endText)
             parcel.writeFloat(textSize)
+            parcel.writeFloat(textSizeBubble)
             parcel.writeInt(colorLabel)
             parcel.writeInt(colorBar)
             parcel.writeInt(colorBarText)
@@ -285,6 +290,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
 
                 position = max(0f, min(1f, a.getFloat(R.styleable.FluidSlider_initial_position, INITIAL_POSITION)))
                 textSize = a.getDimension(R.styleable.FluidSlider_text_size, TEXT_SIZE * density)
+                textSizeBubble = a.getDimension(R.styleable.FluidSlider_text_size, TEXT_SIZE * density)
                 duration = abs(a.getInteger(R.styleable.FluidSlider_duration, ANIMATION_DURATION)).toLong()
 
                 a.getString(R.styleable.FluidSlider_start_text)?.also { startText = it }
@@ -299,6 +305,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
             colorBar = COLOR_BAR
             colorBubble = COLOR_LABEL
             textSize = TEXT_SIZE * density
+            textSizeBubble = TEXT_SIZE * density
             barHeight = BAR_HEIGHT_NORMAL * density
         }
 
@@ -321,7 +328,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
 
     override fun onSaveInstanceState(): Parcelable {
         return State(super.onSaveInstanceState(),
-                position, startText, endText, textSize,
+                position, startText, endText, textSize, textSizeBubble,
                 colorBubble, colorBar, colorBarText, colorBubbleText, duration)
     }
 
@@ -332,6 +339,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
             startText = state.startText
             endText = state.endText
             textSize = state.textSize
+            textSizeBubble = state.textSizeBubble
             colorBubble = state.colorLabel
             colorBar = state.colorBar
             colorBarText = state.colorBarText

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -83,6 +83,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
     private val paintBar: Paint
     private val paintLabel: Paint
     private val paintText: Paint
+    private val paintTextBubble: Paint
 
     private var maxMovement = 0f
     private var touchX: Float? = null
@@ -130,6 +131,15 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
         get() = paintText.textSize
         set(value) {
             paintText.textSize = value
+        }
+
+    /**
+     * Text size.
+     */
+    var textSizeBubble: Float
+        get() = paintTextBubble.textSize
+        set(value) {
+            paintTextBubble.textSize = value
         }
 
     /**
@@ -261,6 +271,7 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
         paintLabel.style = Paint.Style.FILL
 
         paintText = Paint(Paint.ANTI_ALIAS_FLAG)
+        paintTextBubble = Paint(Paint.ANTI_ALIAS_FLAG)
 
         val density = context.resources.displayMetrics.density
 
@@ -369,7 +380,41 @@ class FluidSlider @JvmOverloads constructor(context: Context, attrs: AttributeSe
         canvas.drawOval(rectLabel, paintLabel)
 
         val text = bubbleText ?: (position * 100).toInt().toString()
-        drawText(canvas, paintText, text, Paint.Align.CENTER, colorBubbleText, 0f, rectLabel, rectText)
+        if (text.length > 4)
+            setTextSizeForWidth(paintTextBubble, rectLabel.width() - 10, bubbleText)
+        drawText(canvas, paintTextBubble, text, Paint.Align.CENTER, colorBubbleText, 0f, rectLabel, rectText)
+    }
+
+    /**
+     * Sets the text size for a Paint object so a given string of text will be a
+     * given width.
+     *
+     * @param paint
+     * the Paint to set the text size for
+     * @param desiredWidth
+     * the desired width
+     * @param text
+     * the text that should be that width
+     */
+    private fun setTextSizeForWidth(paint: Paint, desiredWidth: Float,
+                                    text: String?) {
+
+        // Pick a reasonably large value for the test. Larger values produce
+        // more accurate results, but may cause problems with hardware
+        // acceleration. But there are workarounds for that, too; refer to
+        // http://stackoverflow.com/questions/6253528/font-size-too-large-to-fit-in-cache
+        val testTextSize = 48f
+
+        // Get the bounds of the text, using our testTextSize.
+        paint.textSize = testTextSize
+        val bounds = Rect()
+        paint.getTextBounds(text, 0, text!!.length, bounds)
+
+        // Calculate the desired size as a proportion of our testTextSize.
+        val desiredTextSize = testTextSize * desiredWidth / bounds.width()
+
+        // Set the paint for that size.
+        paint.textSize = desiredTextSize
     }
 
     override fun performClick(): Boolean {


### PR DESCRIPTION
Hi, in one app that I'm working I use your widget with big numbers, but I detected that the text in the bubble overflows the bubble itself. This is a little fix to resize text to match the bubble size.