### PR TITLE
Font Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Here are the attributes you can specify through XML or related setters:
 * `duration` - Duration of "bubble" rise in milliseconds.
 * `initial_position` - Initial positon of "bubble" in range form `0.0` to `1.0`.
 * `size` - Height of slider. Can be `small` (40dp) and `normal` (56dp).
+* `slider_font` - Font resource used to render the slider's text.
 
 
 This library is a part of a <a href="https://github.com/Ramotion/android-ui-animation-components-and-libraries"><b>selection of our best UI open-source projects.</b></a>

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -12,6 +12,8 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.view.animation.OvershootInterpolator
+import androidx.annotation.FontRes
+import androidx.core.content.res.ResourcesCompat
 import com.ramotion.fluidslider.FluidSlider.Size.NORMAL
 import com.ramotion.fluidslider.FluidSlider.Size.SMALL
 import kotlin.math.*
@@ -196,6 +198,20 @@ class FluidSlider @JvmOverloads constructor(
      */
     var endTrackingListener: (() -> Unit)? = null
 
+    /**
+     * Font resource used to render the slider's text
+     */
+    @FontRes
+    var fontId: Int = -1
+    set(value) {
+        field = value
+
+        paintText.typeface = value.takeIf { it != -1 }?.let {
+            ResourcesCompat.getFont(context, it)
+        }
+        invalidate()
+    }
+
     @SuppressLint("NewApi")
     inner class OutlineProvider : ViewOutlineProvider() {
         override fun getOutline(v: View?, outline: Outline?) {
@@ -225,6 +241,7 @@ class FluidSlider @JvmOverloads constructor(
         val colorBarText: Int
         val colorLabelText: Int
         val duration: Long
+        val fontId: Int
 
         constructor(superState: Parcelable?,
                     position: Float,
@@ -235,7 +252,8 @@ class FluidSlider @JvmOverloads constructor(
                     colorBar: Int,
                     colorBarText: Int,
                     colorLabelText: Int,
-                    duration: Long) : super(superState) {
+                    duration: Long,
+                    fontId: Int) : super(superState) {
             this.position = position
             this.startText = startText
             this.endText = endText
@@ -245,6 +263,7 @@ class FluidSlider @JvmOverloads constructor(
             this.colorBarText = colorBarText
             this.colorLabelText = colorLabelText
             this.duration = duration
+            this.fontId = fontId
         }
 
         private constructor(parcel: Parcel) : super(parcel) {
@@ -257,6 +276,7 @@ class FluidSlider @JvmOverloads constructor(
             this.colorBarText = parcel.readInt()
             this.colorLabelText = parcel.readInt()
             this.duration = parcel.readLong()
+            this.fontId = parcel.readInt()
         }
 
         override fun writeToParcel(parcel: Parcel, i: Int) {
@@ -270,6 +290,7 @@ class FluidSlider @JvmOverloads constructor(
             parcel.writeInt(colorBarText)
             parcel.writeInt(colorLabelText)
             parcel.writeLong(duration)
+            parcel.writeInt(fontId)
         }
 
         override fun describeContents(): Int = 0
@@ -307,6 +328,8 @@ class FluidSlider @JvmOverloads constructor(
 
                 val defaultBarHeight = if (a.getInteger(R.styleable.FluidSlider_size, 1) == 1) Size.NORMAL.value else Size.SMALL.value
                 barHeight = defaultBarHeight * density
+
+                fontId = a.getResourceId(R.styleable.FluidSlider_slider_font, -1)
             } finally {
                 a.recycle()
             }
@@ -345,7 +368,7 @@ class FluidSlider @JvmOverloads constructor(
     override fun onSaveInstanceState(): Parcelable {
         return State(super.onSaveInstanceState(),
                 position, startText, endText, textSize,
-                colorBubble, colorBar, colorBarText, colorBubbleText, duration)
+                colorBubble, colorBar, colorBarText, colorBubbleText, duration, fontId)
     }
 
     override fun onRestoreInstanceState(state: Parcelable) {
@@ -360,6 +383,7 @@ class FluidSlider @JvmOverloads constructor(
             colorBarText = state.colorBarText
             colorBubbleText = state.colorLabelText
             duration = state.duration
+            fontId = state.fontId
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/fluid-slider/src/main/res/values/attrs.xml
+++ b/fluid-slider/src/main/res/values/attrs.xml
@@ -15,5 +15,6 @@
             <enum name="small" value="0"/>
             <enum name="normal" value="1"/>
         </attr>
+        <attr name="slider_font" format="reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This PR exposes the ability to customize the slider's font using a [font resource](https://developer.android.com/guide/topics/resources/font-resource). 

For example:
- XML: `app:slider_font="@font/karla"`
- Kotlin: `slider.fontId = R.font.karla`

The first attempt at this feature exposed the ability to customize the font using a `Typeface` directly, but there was no way to serialize the `Typeface` object in the `FluidSlider.State` class, so it was decided to allow only font resources.